### PR TITLE
Toggle mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ className =? "TrayCalendar" --> doIgnore
 Suggested configuration for `xmobar` as the clock:
 
 ```
-<action=`traycalendar --no-tray &> /dev/null`><action=`traycalendar &> /dev/null` button=3>%date%</action></action>
+<action=`traycalendar --no-tray --toggle &> /dev/null`>%date%</action>
+```
+You can also add `-t <distance>` and `-l <distance>` or `-r <distance>` to enable fixed positioning,
+where `<distance>` is the distance in pixels from the corresponding side of the screen.
+
+For example: put the window at the right edge of the screen, 30px from the top
+```shell
+$ traycalendar --no-tray -t 30 -r 0
 ```
 
 DEPENDENCIES

--- a/traycalendar.py
+++ b/traycalendar.py
@@ -139,24 +139,28 @@ class CalendarWindow(object):
 
         self.window.add(vbox)
 
+        rootwin = self.window.get_screen().get_root_window()
+        # get_pointer is deprecated but using Gdk.Device.get_position
+        # is not viable here: we have no access to the pointing device.
+        screen, x, y, mask = rootwin.get_pointer()
+
         if fixed_pos:
-            self.position_fixed(pos, window_width)
+            self.position_fixed(pos, window_width, x, y)
         else:
             self.window.set_gravity(Gdk.Gravity.STATIC)
-            rootwin = self.window.get_screen().get_root_window()
-            # get_pointer is deprecated but using Gdk.Device.get_position
-            # is not viable here: we have no access to the pointing device.
-            screen, x, y, mask = rootwin.get_pointer()
             x -= window_width
             # Show the window right beside the cursor.
             self.window.move(x,y)
 
         self.window.show_all()
 
-    def position_fixed(self, pos, window_width):
+    def position_fixed(self, pos, window_width, x, y):
         if pos[1] >= 0:
             self.window.set_gravity(Gdk.Gravity.NORTH_EAST)
-            self.window.move(Gdk.Screen.get_default().get_width() - window_width - pos[1], pos[0])
+            # Gdk.Screen.get_width() is deprecated
+            # The preferred method appears to be as follows
+            screen_width = self.window.get_screen().get_display().get_monitor_at_point(x, y).get_geometry().width
+            self.window.move(screen_width - window_width - pos[1], pos[0])
         else:
             self.window.set_gravity(Gdk.Gravity.NORTH_WEST)
             self.window.move(pos[2], pos[0])


### PR DESCRIPTION
Hi,
I've been using the calendar with xmobar and made some (I think) useful modifications.
This one adds the '--toggle' argument which can be used to make the xmobar <action> into a toggle button (clicking once brings up the calendar, clicking again closes it)

Basically:
`traycalendar --no-tray --toggle` launches the app and opens the window, starting another process `traycalendar --no-tray --toggle` while the first one is still running ends both.